### PR TITLE
Use a theme-check-disable to allow large javascript

### DIFF
--- a/extensions/react-extension/blocks/star_rating.liquid
+++ b/extensions/react-extension/blocks/star_rating.liquid
@@ -1,3 +1,6 @@
+{% # theme-check-disable AssetSizeJavaScript %}
+<script src="{{ 'react-extension.js' | asset_url }}" defer></script>
+{% # theme-check-enable AssetSizeJavaScript %}
 <span>This is liquid</span>
 <div id="container"></div>
 
@@ -5,7 +8,6 @@
   {
     "name": "React Extension Tutorial",
     "target": "section",
-    "javascript": "react-extension.js",
     "settings": []
   }
 {% endschema %}


### PR DESCRIPTION
This PR addresses #1 byadding a `theme-check-disable` for `AssetSizeJavaScript` as documented here: https://shopify.dev/docs/storefronts/themes/tools/theme-check/configuration#disable-checks-using-liquid-comments

The best that I can figure is that this wasn't required in version 2.x of the Shopify CLI but is in 3.x.

Also, I had to change the way the JS was being imported because the include had to be inside the `theme-check-disable` block in the `liquid` template file.  It may be possible to use the `schema` and wrap the `schema` but I didn't see an obvious way in the shallow dive that I did on this.

This change DOES allow you to publish the JS without generating an error, and I tested my developer shop and it worked as expected.